### PR TITLE
[FIX] Erro de path nulo

### DIFF
--- a/Functions/Functions.ps1
+++ b/Functions/Functions.ps1
@@ -70,9 +70,14 @@ Function GetModifiedFilesMap($destPath) {
 		$Null = (Remove-Item $modifiedFilesList_FilePath);
 	}
 	$removedFoldersList = [System.Collections.ArrayList]::new();
-	ForEach($removedFolder In $removedFoldersList_File) {
-		If($removedFolder -Like $wildcardOfRemovedFolder) {
-			$Null = $removedFoldersList.Add($removedFolder);
+	ForEach($removedFolderPath In $removedFoldersList_File) {
+		If(-Not $removedFolderPath) {
+			Continue;
+		}
+		$removedFolderPath = $removedFolderPath.Trim();
+		$removedFolderName = (Split-Path -Path $removedFolderPath -Leaf);
+		If($removedFolderName -Like $wildcardOfRemovedFolder) {
+			$Null = $removedFoldersList.Add($removedFolderPath);
 		}
 	}
 	# Ordena lista de arquivos versionados e removidos, e pastas removidas
@@ -137,8 +142,7 @@ Function GetWillModifyFilesMap($origPath, $destPath) {
 				$Null = $willModifyList.Add($newFile);
 				$willModify = $True;
 			# Arquivo a criar
-			} ElseIf(Test-Path -LiteralPath $oldFilePath -PathType "Leaf") { 
-					# Pastas devem ser listadas pelas a-deletar, mas também lista as presentes
+			} ElseIf(Test-Path -LiteralPath $oldFilePath -PathType "Leaf") { # Pastas devem ser listadas pelas a-deletar, mas também lista as presentes
 				# Não listar arquivos a criar
 				$willModify = $True;
 			}
@@ -200,6 +204,9 @@ Function GetFileMap($filePathList) {
 		}
 		$filePath = $filePath.Trim();
 		$newFile = (GetFileItem $filePath);
+		If(-Not $newFile) {
+			Continue;
+		}
 		$fileBasePath = (Split-Path -Path $filePath -Parent);
 		$baseName = (Join-Path -Path $fileBasePath -ChildPath ($newFile.BaseName + $newFile.Extension));
 		# Ex.:

--- a/Functions/UpdateRemoved.ps1
+++ b/Functions/UpdateRemoved.ps1
@@ -7,7 +7,7 @@
 #     Dessa forma, os que sobrarem são sempre nomeados de $remotionCountdown até 0, do mais novo ao mais antigo
 #   Se $destructive = $False:
 #     Todos serão eventualmente deletados conforme seus contadores atingem [0]
-Function UpdateRemoved($modifiedFilesMap, $removedFolderList, $remotionCountdown, $destructive, $listOnly) {
+Function UpdateRemoved($modifiedFilesMap, $removedFoldersList, $remotionCountdown, $destructive, $listOnly) {
 	If($remotionCountdown -eq 0) {
 		# Com 0, não deve manter removidos
 		$remotionCountdown = -1;
@@ -17,7 +17,7 @@ Function UpdateRemoved($modifiedFilesMap, $removedFolderList, $remotionCountdown
 	$filesToRename = [System.Collections.ArrayList]::new();
 	# Não-Destrutivo = Diminui o RemotionCountdown, e deleta os com RemotionCountdown igual a 0
 	If(-Not $destructive) {
-		ForEach($removedFolder In $removedFolderList) {
+		ForEach($removedFolder In $removedFoldersList) {
 			If(IsFolderEmpty $removedFolder.Path) {
 				$Null = $filesToDelete.Add($removedFolder);
 			}
@@ -45,7 +45,7 @@ Function UpdateRemoved($modifiedFilesMap, $removedFolderList, $remotionCountdown
 		}
 	# Destrutivo = Aplica $remotionCountdown, listando arquivos para renomear ou deletar
 	} Else {
-		ForEach($removedFolder In $removedFolderList) {
+		ForEach($removedFolder In $removedFoldersList) {
 			If(IsFolderEmpty $removedFolder.Path) {
 				$Null = $filesToDelete.Add($removedFolder);
 			}


### PR DESCRIPTION
- (ALT) 'UpdateRemoved': Renomeado variável
- (FIX) 'Functions': Ao listar pastas removidas, um path vazio resultava em um item nulo